### PR TITLE
Clicking a TV episode in the "New Episodes" widget should just play that episode

### DIFF
--- a/lib/resources/lib/indexers/episodes.py
+++ b/lib/resources/lib/indexers/episodes.py
@@ -577,7 +577,7 @@ class episodes:
             pass
 
 
-    def calendar(self, url):
+    def calendar(self, url, click=None):
         try:
             try: url = getattr(self, url + '_link')
             except: pass
@@ -611,7 +611,7 @@ class episodes:
                 self.list = cache.get(self.tvmaze_list, 1, url, False)
 
 
-            self.episodeDirectory(self.list)
+            self.episodeDirectory(self.list, click)
             return self.list
         except:
             pass
@@ -624,11 +624,11 @@ class episodes:
             setting = control.setting('tv.widget')
 
         if setting == '2':
-            self.calendar(self.progress_link)
+            self.calendar(self.progress_link, 'play')
         elif setting == '3':
-            self.calendar(self.mycalendar_link)
+            self.calendar(self.mycalendar_link, 'play')
         else:
-            self.calendar(self.added_link)
+            self.calendar(self.added_link, 'play')
 
 
     def calendars(self, idx=True):
@@ -1352,7 +1352,7 @@ class episodes:
         return itemlist
 
 
-    def episodeDirectory(self, items):
+    def episodeDirectory(self, items, click=None):
         if items == None or len(items) == 0: control.idle() ; sys.exit()
 
         sysaddon = sys.argv[0]
@@ -1377,9 +1377,11 @@ class episodes:
         multi = len([x for y,x in enumerate(multi) if x not in multi[:y]])
         multi = True if multi > 1 else False
 
-        try: sysaction = items[0]['action']
-        except: sysaction = ''
-
+        if click == None:
+            try: sysaction = items[0]['action']
+            except: sysaction = ''
+        else:
+            sysaction = click
         isFolder = False if not sysaction == 'episodes' else True
 
         playbackMenu = control.lang(32063).encode('utf-8') if control.setting('hosts.mode') == '2' else control.lang(32064).encode('utf-8')

--- a/lib/resources/lib/sources/en/allrls.py
+++ b/lib/resources/lib/sources/en/allrls.py
@@ -137,8 +137,6 @@ class source:
                             
                             if any(x in url.upper() for x in ['HEVC', 'X265', 'H265']): info.append('HEVC')
                             
-                            info.append('ALLRLS')
-                            
                             info = ' | '.join(info)
                             
                             host = client.replaceHTMLCodes(host)


### PR DESCRIPTION
rather than opening a directory with all unwatched episodes for that show.

Users wanting to keep the existing behaviour can still find it under "My TV Shows".