### PR TITLE
Fix new option for "New Movies" shortcut

### DIFF
--- a/lib/resources/lib/indexers/movies.py
+++ b/lib/resources/lib/indexers/movies.py
@@ -87,8 +87,8 @@ class movies:
             self.language_link = 'http://www.imdb.com/search/title?title_type=feature,tv_movie&num_votes=100,&production_status=released&primary_language=%s&sort=moviemeter,asc&count=40&start=1'
             self.certification_link = 'http://www.imdb.com/search/title?title_type=feature,tv_movie&num_votes=100,&production_status=released&certificates=us:%s&sort=moviemeter,asc&count=40&start=1'
             self.boxoffice_link = 'http://www.imdb.com/search/title?title_type=feature,tv_movie&production_status=released&sort=boxoffice_gross_us,desc&count=40&start=1'
-            self.added_link  = 'http://www.imdb.com/search/title?title_type=feature,tv_movie&languages=en&num_votes=500,&production_status=released&release_date=%s,%s&sort=release_date,desc&count=20&start=1' % (self.year_date, self.today_date)
 
+        self.added_link  = 'http://www.imdb.com/search/title?title_type=feature,tv_movie&languages=en&num_votes=500,&production_status=released&release_date=%s,%s&sort=release_date,desc&count=20&start=1' % (self.year_date, self.today_date)
         self.trending_link = 'http://api.trakt.tv/movies/trending?limit=40&page=1'
         self.traktlists_link = 'http://api.trakt.tv/users/me/lists'
         self.traktlikedlists_link = 'http://api.trakt.tv/users/likes/lists?limit=1000000'


### PR DESCRIPTION
The new option Films/TV-Movies (strange label, btw ;) ) causes an exception when the **Hide Movies in Cinema** option is activated and the user tries to open this list, b/c *self.added_link* is not defined but referred.

Log snippet : 
```
23:58:14.919 T:8788   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.AttributeError'>
                                            Error Contents: movies instance has no attribute 'added_link'
                                            Traceback (most recent call last):
                                              File "C:\Users\Ingo\AppData\Roaming\Kodi\addons\plugin.video.covenant\covenant.py", line 139, in <module>
                                                movies.movies().widget()
                                              File "C:\Users\Ingo\AppData\Roaming\Kodi\addons\script.module.covenant\lib\resources\lib\indexers\movies.py", line 164, in widget
                                                self.get(self.added_link)
                                            AttributeError: movies instance has no attribute 'added_link'
                                            -->End of Python script error report<--
23:58:15.057 T:6320   ERROR: XFILE::CDirectory::GetDirectory - Error getting plugin://plugin.video.covenant/?action=movieWidget
23:58:15.061 T:6320   ERROR: CGUIMediaWindow::GetDirectory(plugin://plugin.video.covenant/?action=movieWidget) failed

```