### PR TITLE
Progressbar

### DIFF
--- a/lib/resources/lib/modules/sources.py
+++ b/lib/resources/lib/modules/sources.py
@@ -378,7 +378,8 @@ class sources:
                         if len(info) > 6: line2 = string3 % (str(len(info)))
                         elif len(info) > 0: line2 = string3 % (', '.join(info))
                         else: break
-                        progressDialog.update(min(100, int(100 * (float(i) / 2) / timeout + 0.5)), line1, line2)
+                        percent = int(100 * float(i) / (2 * timeout) + 0.5)
+                        progressDialog.update(max(1, percent), line1, line2)
                     except:
                         pass
                 else:
@@ -389,7 +390,8 @@ class sources:
                         if len(info) > 6: line2 = 'Waiting for: %s' % (str(len(info)))
                         elif len(info) > 0: line2 = 'Waiting for: %s' % (', '.join(info))
                         else: break
-                        progressDialog.update(100, line1, line2)
+                        percent = int(100 * float(i) / (2 * timeout) + 0.5) % 100
+                        progressDialog.update(max(1, percent), line1, line2)
                     except:
                         break
 

--- a/lib/resources/lib/modules/sources.py
+++ b/lib/resources/lib/modules/sources.py
@@ -372,21 +372,22 @@ class sources:
                 if (i / 2) < timeout:
                     try:
                         info = [sourcelabelDict[x.getName()] for x in threads if x.is_alive() == True]
-                        string4 = 'Sources Found: %s' % (len(self.sources))
-                        if len(info) > 5: string5 = string3 % (str(len(info)))
-                        elif len(info) > 0: string5 = string3 % (', '.join(info))
+                        line1 = 'Sources found: %s' % (len(self.sources))
+                        if len(info) > 6: line2 = string3 % (str(len(info)))
+                        elif len(info) > 0: line2 = string3 % (', '.join(info))
                         else: break
-                        progressDialog.update(min(100, int(100 * (float(i) / 2) / timeout + 0.5)), str(string4), str(string5))
+                        progressDialog.update(min(100, int(100 * (float(i) / 2) / timeout + 0.5)), line1, line2)
                     except:
                         pass
                 else:
                     try:
-                        info = [sourcelabelDict[x.getName()] for x in threads if x.is_alive() == True and x.getName() in mainsourceDict]
-                        string4 = 'Sources Found: %s' % (len(self.sources))
-                        if len(info) > 5: string5 = 'Waiting For: %s' % (str(len(info)))
-                        elif len(info) > 0: string5 = 'Waiting For: %s' % (', '.join(info))
+                        mainleft = [sourcelabelDict[x.getName()] for x in threads if x.is_alive() == True and x.getName() in mainsourceDict]
+                        info = mainleft
+                        line1 = 'Sources found: %s' % (len(self.sources))
+                        if len(info) > 6: line2 = 'Waiting for: %s' % (str(len(info)))
+                        elif len(info) > 0: line2 = 'Waiting for: %s' % (', '.join(info))
                         else: break
-                        progressDialog.update(100, str(string4), str(string5))
+                        progressDialog.update(100, line1, line2)
                     except:
                         break
 

--- a/lib/resources/lib/modules/sources.py
+++ b/lib/resources/lib/modules/sources.py
@@ -373,7 +373,7 @@ class sources:
                     try:
                         mainleft = [sourcelabelDict[x.getName()] for x in threads if x.is_alive() == True and x.getName() in mainsourceDict]
                         info = [sourcelabelDict[x.getName()] for x in threads if x.is_alive() == True]
-                        if len(mainleft) == 0 and len(info) <= 2 and len(self.sources) > 99: break # improve responsiveness
+                        if i >= timeout and len(mainleft) == 0 and len(self.sources) >= 100 * len(info): break # improve responsiveness
                         line1 = 'Sources found: %s' % (len(self.sources))
                         if len(info) > 6: line2 = string3 % (str(len(info)))
                         elif len(info) > 0: line2 = string3 % (', '.join(info))

--- a/lib/resources/lib/modules/sources.py
+++ b/lib/resources/lib/modules/sources.py
@@ -371,7 +371,9 @@ class sources:
 
                 if (i / 2) < timeout:
                     try:
+                        mainleft = [sourcelabelDict[x.getName()] for x in threads if x.is_alive() == True and x.getName() in mainsourceDict]
                         info = [sourcelabelDict[x.getName()] for x in threads if x.is_alive() == True]
+                        if len(mainleft) == 0 and len(info) <= 2 and len(self.sources) > 99: break # improve responsiveness
                         line1 = 'Sources found: %s' % (len(self.sources))
                         if len(info) > 6: line2 = string3 % (str(len(info)))
                         elif len(info) > 0: line2 = string3 % (', '.join(info))

--- a/lib/resources/lib/modules/sources.py
+++ b/lib/resources/lib/modules/sources.py
@@ -328,6 +328,9 @@ class sources:
 
         sourceDict = [(i[0], i[1], i[1].priority) for i in sourceDict]
 
+        random.shuffle(sourceDict)
+        sourceDict = sorted(sourceDict, key=lambda i: i[2])
+
         threads = []
 
         if content == 'movie':
@@ -357,33 +360,35 @@ class sources:
         try: timeout = int(control.setting('scrapers.timeout.1'))
         except: pass
 
-        for i in range(0, (timeout * 2) + 60):
+        for i in range(0, 2 * max(timeout, 30)):
             try:
                 if xbmc.abortRequested == True: return sys.exit()
-
-                try: info = [sourcelabelDict[x.getName()] for x in threads if x.is_alive() == True]
-                except: info = []
-
-                timerange = int(i * 0.5)
 
                 try:
                     if progressDialog.iscanceled(): break
                 except:
                     pass
-                try:
-                    string4 = string1 % str(timerange)
-                    if len(info) > 5: string5 = string3 % str(len(info))
-                    else: string5 = string3 % str(info).translate(None, "[]'")
-                    progressDialog.update(int((100 / float(len(threads))) * len([x for x in threads if x.is_alive() == False])), str(string4), str(string5))
-                except:
-                    pass
 
-                is_alive = [x.is_alive() for x in threads]
-                if all(x == False for x in is_alive): break
-
-                if timerange >= timeout:
-                    is_alive = [x for x in threads if x.is_alive() == True and x.getName() in mainsourceDict]
-                    if not is_alive: break
+                if (i / 2) < timeout:
+                    try:
+                        info = [sourcelabelDict[x.getName()] for x in threads if x.is_alive() == True]
+                        string4 = 'Sources Found: %s' % (len(self.sources))
+                        if len(info) > 5: string5 = string3 % (str(len(info)))
+                        elif len(info) > 0: string5 = string3 % (', '.join(info))
+                        else: break
+                        progressDialog.update(min(100, int(100 * (float(i) / 2) / timeout + 0.5)), str(string4), str(string5))
+                    except:
+                        pass
+                else:
+                    try:
+                        info = [sourcelabelDict[x.getName()] for x in threads if x.is_alive() == True and x.getName() in mainsourceDict]
+                        string4 = 'Sources Found: %s' % (len(self.sources))
+                        if len(info) > 5: string5 = 'Waiting For: %s' % (str(len(info)))
+                        elif len(info) > 0: string5 = 'Waiting For: %s' % (', '.join(info))
+                        else: break
+                        progressDialog.update(100, str(string4), str(string5))
+                    except:
+                        break
 
                 time.sleep(0.5)
             except:

--- a/lib/resources/lib/modules/sources.py
+++ b/lib/resources/lib/modules/sources.py
@@ -360,7 +360,7 @@ class sources:
         try: timeout = int(control.setting('scrapers.timeout.1'))
         except: pass
 
-        for i in range(0, 2 * max(timeout, 30)):
+        for i in range(0, 4 * timeout):
             try:
                 if xbmc.abortRequested == True: return sys.exit()
 


### PR DESCRIPTION
A bunch of related changes, bundled together...

- don't wait for all the non-priority=0 threads if we have a lot of sources already
- rather than arbitrarily adding 30 seconds to the timeout, we double it
- (same behaviour at the default 30 seconds timeout, more aggressive than default if user has lowered it)
- try to make priority=0 threads start first
- percentage bar is time-based, not number of running threads, so it sweeps smoothly and doesn't freeze
- if we're waiting on a priority=0 thread, make that clearer to the users