### PR TITLE
Fixed "Marked As Watched" when media were added to local library

### DIFF
--- a/lib/resources/lib/modules/player.py
+++ b/lib/resources/lib/modules/player.py
@@ -265,6 +265,9 @@ class player(xbmc.Player):
         if control.setting('crefresh') == 'true':
             xbmc.executebuiltin('Container.Refresh')
 
+        if (self.currentTime / self.totalTime) >= .90:
+            self.libForPlayback()
+
 
     def onPlayBackEnded(self):
         self.libForPlayback()


### PR DESCRIPTION
It would be really nice when you can add this to your code because now it is possible to add media to local library and track the watchstats without trakt.tv