### PR TITLE
big speed up between scanning providers and results appearing

### DIFF
--- a/lib/resources/lib/modules/sources.py
+++ b/lib/resources/lib/modules/sources.py
@@ -105,6 +105,9 @@ class sources:
         meta = control.window.getProperty(self.metaProperty)
         meta = json.loads(meta)
 
+        # (Kodi bug?) [name,role] is incredibly slow on this directory, [name] is barely tolerable, so just nuke it for speed!
+        if 'cast' in meta: del(meta['cast'])
+
         sysaddon = sys.argv[0]
 
         syshandle = int(sys.argv[1])


### PR DESCRIPTION
It looks like Kodi is not very efficient handling cast lists, particularly the [name,role] format. Multiply this by 800 video sources in one big list, and you can wait a long time between the providers being scanned and the results actually appearing on screen.

This change just drops the cast list entirely from this one directory, saving nearly a minute in one extreme case with a cast list in the hundreds, or 4 seconds for a much more typical case (a cast of 15).